### PR TITLE
feat: ✨ add LibRepl library

### DIFF
--- a/Libraries/CMakeLists.txt
+++ b/Libraries/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(LibConfig)
+add_subdirectory(LibRepl)

--- a/Libraries/LibRepl/CMakeLists.txt
+++ b/Libraries/LibRepl/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(SRC
+        Token.cpp
+        Token.h
+        Tokenizer.cpp
+        Tokenizer.h
+        Parser.cpp
+        Parser.h
+        Repl.cpp
+        Repl.h
+        Command.cpp
+        Command.h
+)
+
+add_library(LibRepl ${SRC})
+target_include_directories(LibRepl PUBLIC .)
+
+target_link_libraries(LibRepl PRIVATE AK)

--- a/Libraries/LibRepl/Command.cpp
+++ b/Libraries/LibRepl/Command.cpp
@@ -1,0 +1,1 @@
+#include "Command.h"

--- a/Libraries/LibRepl/Command.h
+++ b/Libraries/LibRepl/Command.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+namespace LibRepl {
+    class Command final {
+    private:
+        std::string m_command;
+    };
+}

--- a/Libraries/LibRepl/Parser.cpp
+++ b/Libraries/LibRepl/Parser.cpp
@@ -1,0 +1,1 @@
+#include "Parser.h"

--- a/Libraries/LibRepl/Parser.h
+++ b/Libraries/LibRepl/Parser.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/Libraries/LibRepl/Repl.cpp
+++ b/Libraries/LibRepl/Repl.cpp
@@ -1,0 +1,1 @@
+#include "Repl.h"

--- a/Libraries/LibRepl/Repl.h
+++ b/Libraries/LibRepl/Repl.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/Libraries/LibRepl/Token.cpp
+++ b/Libraries/LibRepl/Token.cpp
@@ -1,0 +1,1 @@
+#include "Token.h"

--- a/Libraries/LibRepl/Token.h
+++ b/Libraries/LibRepl/Token.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <string>
+
+namespace LibRepl {
+    enum class TokenType {
+        Identifier,
+        Dollar,
+        EQ,
+        OpenCurlyBrace,
+        CloseCurlyBrace,
+        OpenBrace,
+        CloseBrace,
+        Pipe,
+        DoubleQuote,
+        SingleQuote
+    };
+
+    struct Token {
+        TokenType type;
+        std::string value;
+    };
+}

--- a/Libraries/LibRepl/Tokenizer.cpp
+++ b/Libraries/LibRepl/Tokenizer.cpp
@@ -1,0 +1,31 @@
+#include "Tokenizer.h"
+
+#include <utility>
+#include <Utils.hpp>
+
+LibRepl::Tokenizer::Tokenizer(std::string input)
+    : m_input(std::move(input))
+{
+}
+
+std::vector<LibRepl::Token> LibRepl::Tokenizer::tokenize()
+{
+    std::string token;
+    for (size_t i = 0; i < m_input.size(); ++i) {
+        token += m_input[i];
+        if (token == " ") {
+            token = "";
+            continue;
+        }
+        if (m_input[i] == ' ' || i == m_input.size() - 1) {
+            m_tokens.push_back(Token{ TokenType::Identifier, trim_copy(token) });
+            token = "";
+            continue;
+        }
+        if (m_input[i] == '|') {
+            m_tokens.push_back(Token{ TokenType::Pipe, "|" });
+            token = "";
+        }
+    }
+    return m_tokens;
+}

--- a/Libraries/LibRepl/Tokenizer.h
+++ b/Libraries/LibRepl/Tokenizer.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include "Token.h"
+
+namespace LibRepl {
+    class Tokenizer {
+    public:
+        explicit Tokenizer(std::string input);
+        std::vector<Token> tokenize();
+    private:
+        std::string m_input{};
+        std::vector<Token> m_tokens{};
+    };
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,3 @@
 enable_testing()
 add_subdirectory(LibConfig)
+add_subdirectory(LibRepl)

--- a/tests/LibRepl/CMakeLists.txt
+++ b/tests/LibRepl/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_executable(
+        librepl_test
+        TokenizerTest.cpp
+)
+target_link_libraries(
+        librepl_test
+        GTest::gtest_main
+        LibRepl
+)
+
+include(GoogleTest)
+gtest_discover_tests(librepl_test)

--- a/tests/LibRepl/TokenizerTest.cpp
+++ b/tests/LibRepl/TokenizerTest.cpp
@@ -1,0 +1,43 @@
+#include "Tokenizer.h"
+#include <gtest/gtest.h>
+
+class TokenizerTest : public ::testing::Test { };
+
+TEST_F(TokenizerTest, TestBasicCommandInput)
+{
+    LibRepl::Tokenizer tokenizer("cd /home/user/code/lake");
+    auto tokens = tokenizer.tokenize();
+    ASSERT_EQ(tokens.size(), 2);
+    ASSERT_EQ(tokens[0].type, LibRepl::TokenType::Identifier);
+    ASSERT_EQ(tokens[1].type, LibRepl::TokenType::Identifier);
+    ASSERT_EQ(tokens[0].value, "cd");
+    ASSERT_EQ(tokens[1].value, "/home/user/code/lake");
+}
+
+TEST_F(TokenizerTest, TestBasicCommandWithDashParams)
+{
+    LibRepl::Tokenizer tokenizer("ls -latr");
+    auto tokens = tokenizer.tokenize();
+    ASSERT_EQ(tokens.size(), 2);
+    ASSERT_EQ(tokens[0].type, LibRepl::TokenType::Identifier);
+    ASSERT_EQ(tokens[1].type, LibRepl::TokenType::Identifier);
+    ASSERT_EQ(tokens[0].value, "ls");
+    ASSERT_EQ(tokens[1].value, "-latr");
+}
+
+TEST_F(TokenizerTest, TestBasicCommandPipe)
+{
+    LibRepl::Tokenizer tokenizer("ls -latr | grep hello");
+    auto tokens = tokenizer.tokenize();
+    ASSERT_EQ(tokens.size(), 5);
+    ASSERT_EQ(tokens[0].type, LibRepl::TokenType::Identifier);
+    ASSERT_EQ(tokens[1].type, LibRepl::TokenType::Identifier);
+    ASSERT_EQ(tokens[2].type, LibRepl::TokenType::Pipe);
+    ASSERT_EQ(tokens[3].type, LibRepl::TokenType::Identifier);
+    ASSERT_EQ(tokens[4].type, LibRepl::TokenType::Identifier);
+    ASSERT_EQ(tokens[0].value, "ls");
+    ASSERT_EQ(tokens[1].value, "-latr");
+    ASSERT_EQ(tokens[2].value, "|");
+    ASSERT_EQ(tokens[3].value, "grep");
+    ASSERT_EQ(tokens[4].value, "hello");
+}


### PR DESCRIPTION
Introduce the LibRepl library for REPL functionality, including tokenization, parsing, and command handling.
- Added `Token`, `Tokenizer`, `Parser`, `Command`, and `Repl` components.
- Implemented a basic tokenizer to handle commands and pipes.
- Integrated LibRepl into the build system and added tests for Tokenizer.